### PR TITLE
Ensure change event is still fired

### DIFF
--- a/jquery.miniColors.js
+++ b/jquery.miniColors.js
@@ -180,7 +180,8 @@ if(jQuery) (function($) {
 				input.data('huePicker', selector.find('.miniColors-huePicker'));
 				input.data('colorPicker', selector.find('.miniColors-colorPicker'));
 				input.data('mousebutton', 0);
-				
+				var oldValue = input.val();
+
 				$('BODY').append(selector);
 				selector.fadeIn(100);
 				
@@ -208,7 +209,11 @@ if(jQuery) (function($) {
 					}
 					
 					if( $(event.target).parents().andSelf().hasClass('miniColors') ) return;
-					
+
+					if(input.val() != oldValue) {
+						input.trigger('change');
+					}
+
 					hide(input);
 				});
 				


### PR DESCRIPTION
My app uses the change event to trigger a save.  If the user typed a color, things would still work.  Mousing a color, though, would fail to save the change.  This fixes it.
