### PR TITLE
Fix readme.md "Usage" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,9 @@ http://labs.abeautifulsite.net/jquery-miniColors/
 
 ## Usage
 
-1. Link to jQuery: <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.0/jquery.min.js"></script>
-2. Link to miniColors: <script type="text/javascript" src="jquery.miniColors.js"></script>
-3. Include miniColors stylesheet: <link type="text/css" rel="stylesheet" href="jquery.miniColors.css" />
+1. Link to jQuery: `<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.0/jquery.min.js"></script>`
+2. Link to miniColors: `<script type="text/javascript" src="jquery.miniColors.js"></script>`
+3. Include miniColors stylesheet: `<link type="text/css" rel="stylesheet" href="jquery.miniColors.css" />`
 4. Apply $([selector]).miniColors() to one or more INPUT elements
 
 


### PR DESCRIPTION
Just nit-picking the readme file: code-quoted the `<script>` and `<link>` tags.

They were not showing up on Github.
