### PR TITLE
Fix typo that prevented colour pickers from being cleared correctly.

### DIFF
--- a/jquery.miniColors.js
+++ b/jquery.miniColors.js
@@ -233,7 +233,7 @@ if(jQuery) (function($) {
 				// Hide all other instances if input isn't specified
 				if( !input ) input = $( '.miniColors' );
 				
-				$(input).each( function() {
+				input.each( function() {
 					var selector = $(this).data('selector');
 					$(this).removeData('selector');
 					$(selector).fadeOut(100, function() {


### PR DESCRIPTION
I ran into a small issue where clicking between two colour picker inputs would leave an old instance of a colour picker in the DOM. When looking through the code, I stumbled into that particular line which seems to be a mistake. Amending it cleared up the problem.
