### PR TITLE
Fix returning null while setting data

### DIFF
--- a/jquery.miniColors.js
+++ b/jquery.miniColors.js
@@ -33,6 +33,7 @@ if(jQuery) (function($) {
 				} else {
 					// This is used in .data() so has to exist
 					o.opacity = false;
+					alpha = 1;
 					input.removeAttr('data-opacity');
 				}
 				


### PR DESCRIPTION
o.opacity was sometimes undefined, causing the data() call to return
null instead of setting the opacity data to null.
