### PR TITLE
Fix error in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name"         : "jquery-miniColors",
-    "version"      : "2.0-beta.1",
+    "version"      : "2.0.0-beta.1",
     "description"  : "jQuery MiniColors Plugin",
     "homepage"     : "",
     "main"         : [ "./jquery.miniColors.js", "./jquery.miniColors.css" ],


### PR DESCRIPTION
component.json version name is incorrect, since it's supposed to be written following the semantic versioning standards ( http://semver.org/ ). This doesn't allow for spaces. Pre-release versions must be written by appending a dash, and then groups of alfa-numeric strings separated by dots.
