### PR TITLE
Fix for issue #48: allow to pass explicit inputs to init method

### DIFF
--- a/jquery.miniColors.js
+++ b/jquery.miniColors.js
@@ -22,8 +22,9 @@ if(jQuery) (function($) {
 		},
 		
 		// Initialized all controls of type=minicolors
-		init: function() {
-			$('INPUT[type=minicolors]').each( function() {
+		init: function(inputs) {
+			if(arguments.length == 0) inputs = $('INPUT[type=minicolors]');
+			inputs.each( function() {
 				init( $(this) );
 			});
 		},


### PR DESCRIPTION
Super simple 3 line change to the init method that allows to pass explicit inputs, hope you'll pull it in soon.
