### PR TITLE
Expose the version of the library.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ _Copyright Cory LaViska for A Beautiful Site, LLC. (http://www.abeautifulsite.ne
 
 _Dual-licensed under the MIT and GPL Version 2 licenses_
 
+Version: 2.0.0-beta3
 
 ## Demo & Documentation
 


### PR DESCRIPTION
In order to let users track more easily what they are downloading and to allow some tools\* to extract the version of the library, you should display it either as a variable of the library or in the README file. Here is a commit to put it in the README.

*tools: Drupal.org doesn't allow the direct hosting of libraries, we need to use the Libraries API instead and this module requires to parse the version of the library. Here is why i'm sending you this pull request.
