### PR TITLE
Changing the input triggers 'input' and 'change' events

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -627,8 +627,7 @@ if(jQuery) (function($) {
 					settings.change.call(input.get(0), hex, opacity);
 				}
 			}
-			input.trigger('change');
-			input.trigger('input');
+			input.trigger('change').trigger('input');
 		}
 	
 	}


### PR DESCRIPTION
For being consistent with jQuery, I think is a good idea to trigger those events once the input changes.
