### PR TITLE
prevent fadeOut for each ever opend panels

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -227,19 +227,14 @@ if(jQuery) (function($) {
 	// Hides all dropdown panels
 	function hide() {
 		
-		$('.minicolors-input').each( function() {
-			
-			var input = $(this),
-				settings = input.data('minicolors-settings'),
-				minicolors = input.parent();
-			
-			// Don't hide inline controls
-			if( settings.inline ) return;
-			
+		$('.minicolors-focus').each( function() {
+
+			var minicolors = $(this),
+				input = minicolors.find('.minicolors-input'),
+				settings = input.data('minicolors-settings');
+
 			minicolors.find('.minicolors-panel').fadeOut(settings.hideSpeed, function() {
-				if(minicolors.hasClass('minicolors-focus')) {
-					if( settings.hide ) settings.hide.call(input.get(0));
-				}
+				if( settings.hide ) settings.hide.call(input.get(0));
 				minicolors.removeClass('minicolors-focus');
 			});			
 						


### PR DESCRIPTION
We have a site with many (40+) instances of this great MiniColors
plugin. After a while, when opening different instances it becomes very
slow. 
I have done a fork/patch. Please review. 
