### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   "main": [
     "./jquery.minicolors.js",
     "./jquery.minicolors.css"
-  ]
+  ],
   "keywords": [
     "jquery",
     "colorpicker"


### PR DESCRIPTION
bower.json is missing a comma and therefore it is malformed, causing bower install to fail.
