### PR TITLE
fix: bootstrap 3.1+ compatibility #147

### DIFF
--- a/jquery.minicolors.css
+++ b/jquery.minicolors.css
@@ -240,6 +240,7 @@
 	width: 28px;
 	height: 28px;
 	border-radius: 3px;
+	z-index: 2;
 }
 .minicolors-theme-bootstrap .minicolors-swatch-color {
 	border-radius: inherit;
@@ -250,6 +251,7 @@
 }
 .minicolors-theme-bootstrap .minicolors-input {
 	padding-left: 44px;
+	float: none !important;
 }
 .minicolors-theme-bootstrap.minicolors-position-right .minicolors-input {
 	padding-right: 44px;


### PR DESCRIPTION
I was digging around a bit and found a fix (hopefully ;))
I've checked it with most browsers including IE 9+ and all major versions of Bootstrap 3.
Everything works as intended.

There were two fixes in Bootstrap which affected minicolors:
z-index: https://github.com/twbs/bootstrap/commit/eb20d6f13244052f7794825531c9ee7e76430559
float: https://github.com/twbs/bootstrap/commit/432b9f9cde8e2b067fd54ed148c5f8df510e30c5

The swatch was not visible in 3.3.1 anymore, as Bootstrap changed the z-index of the input field to 2.
I changed the z-index in the bootstrap-theme to 2 as well.

The positioning issue was related to the input field's float:left; introduced in Bootstrap 3.1.0.
The input's floating is now overwritten to none.