### PR TITLE
Cursor should be default when hidden and disabled

### DIFF
--- a/jquery.minicolors.css
+++ b/jquery.minicolors.css
@@ -35,6 +35,10 @@
     cursor: pointer;
 }
 
+.minicolors input[type=hidden][disabled] + .minicolors-swatch {
+    cursor: default;
+}
+
 /* Panel */
 .minicolors-panel {
     position: absolute;


### PR DESCRIPTION
Handle cursor above disabled colorpicker-input can confuse because in this case click does nothing. I suggest to show default cursor in this case.