### PR TITLE
rgba input values, and css color keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
     <meta charset="utf-8">
 
     <!-- jQuery -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
     <!-- Bootstrap 3 -->
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+    <script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
     <!-- MiniColors -->
     <script src="jquery.minicolors.js"></script>
@@ -63,6 +63,8 @@
                 $(this).minicolors({
                     control: $(this).attr('data-control') || 'hue',
                     defaultValue: $(this).attr('data-defaultValue') || '',
+                    format: $(this).attr('data-format') || 'hex',
+                    keywords: $(this).attr('data-keywords') || '',
                     inline: $(this).attr('data-inline') === 'true',
                     letterCase: $(this).attr('data-letterCase') || 'lowercase',
                     opacity: $(this).attr('data-opacity'),
@@ -222,6 +224,35 @@
                 </div>
             </div>
 
+            <!-- RGB(A) -->
+            <h3>RGB(A)</h3>
+            <div class="well">
+                <div class="row">
+                    <div class="col-lg-4 col-sm-4 col-12">
+                        <div class="form-group">
+                            <label for="rgb">RGB</label>
+                            <br>
+                            <input type="text" id="rgb" class="form-control demo" data-format="rgb" value="rgb(33, 147, 58)">
+                            <span class="help-block">
+                                RGB input can be assigned by including the <code>data-format</code> attribute
+                                or by setting the <code>format</code> option to <code>rgb</code>.
+                            </span>
+                        </div>
+                    </div>
+                    <div class="col-lg-4 col-sm-4 col-12">
+                        <div class="form-group">
+                            <label for="rgba">RGB(A)</label>
+                            <br>
+                            <input type="text" id="rgba" class="form-control demo" data-format="rgb" data-opacity=".5" value="rgba(52, 64, 158, 0.5)">
+                            <span class="help-block">
+                                RGB(A) input can be assigned by including the <code>data-format</code> and <code>data-opacity</code> attributes
+                                or by setting the <code>format</code> option to <code>rgb</code> and <code>opacity</code> option to <code>true</code>.
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- and more -->
             <h3>&hellip;and more!</h3>
             <div class="well">
@@ -237,6 +268,20 @@
                             </span>
                         </div>
                     </div>
+                    <div class="col-lg-4 col-sm-4 col-12">
+                        <div class="form-group">
+                            <label for="keywords">Keywords</label>
+                            <br>
+                            <input type="text" id="keywords" class="form-control demo" data-keywords="transparent, initial, inherit" value="transparent">
+                            <span class="help-block">
+                                CSS-wide keywords can be assigned by including the <code>data-keywords</code> attribute
+                                or by setting the <code>keywords</code> option to a comma-separated list of valid keywords: <code>transparent, initial, inherit</code>.<br />
+                                <small>Note: <code>none</code> is accepted, but will be converted to valid <code>transparent</code>.</small>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
                     <div class="col-lg-4 col-sm-4 col-12">
                         <div class="form-group">
                             <label for="default-value">Default Value</label>
@@ -317,9 +362,11 @@ $.minicolors = {
         control: 'hue',
         dataUris: true,
         defaultValue: '',
+        format: 'hex',
         hide: null,
         hideSpeed: 100,
         inline: false,
+        keywords: '',
         letterCase: 'lowercase',
         opacity: false,
         position: 'bottom left',

--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -530,7 +530,7 @@
 
         // Determine hex/HSB values
         if( isRgb(input.val()) ) {
-            // If rgb(a) string, converts it to hex and update opacity
+            // If input value is a rgb(a) string, convert it to hex color and update opacity
             hex = rgbString2hex(input.val());
             alpha = keepWithin(parseFloat(getAlpha(input.val())).toFixed(2), 0, 1);
             if( alpha ) {

--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -65,20 +65,6 @@
                     hide();
                     return $(this);
 
-                // Get/set format
-                case 'format':
-                    // Getter
-                    if( data === undefined ) {
-                        // Getter
-                        return $(this).attr('data-format');
-                    } else {
-                        // Setter
-                        $(this).each( function() {
-                            updateFromInput($(this).attr('data-format', data));
-                        });
-                    }
-                    return $(this);
-
                 // Get/set opacity
                 case 'opacity':
                     // Getter

--- a/without-bootstrap.html
+++ b/without-bootstrap.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
 
     <!-- jQuery -->
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
     <!-- MiniColors -->
     <script src="jquery.minicolors.js"></script>
@@ -49,6 +49,8 @@
                 $(this).minicolors({
                     control: $(this).attr('data-control') || 'hue',
                     defaultValue: $(this).attr('data-defaultValue') || '',
+                    format: $(this).attr('data-format') || 'hex',
+                    keywords: $(this).attr('data-keywords') || '',
                     inline: $(this).attr('data-inline') === 'true',
                     letterCase: $(this).attr('data-letterCase') || 'lowercase',
                     opacity: $(this).attr('data-opacity'),
@@ -132,12 +134,30 @@
         <input type="text" id="position-top-right" class="demo" data-position="top right" value="#0088cc">
     </div>
 
+    <!-- RGB(A) -->
+    <h3>RGB(A)</h3>
+    <div class="form-group">
+        <label for="rgb">rgb</label>
+        <br>
+        <input type="text" id="rgb" class="demo" data-format="rgb" value="rgb(33, 147, 58)">
+    </div>
+    <div class="form-group">
+        <label for="rgba">rgb(a)</label>
+        <br>
+        <input type="text" id="rgba" class="demo" data-format="rgb" data-opacity=".5" value="rgba(52, 64, 158, 0.5)">
+    </div>
+
     <!-- and more -->
     <h3>&hellip;and more!</h3>
     <div class="form-group">
         <label for="opacity">Opacity</label>
         <br>
         <input type="text" id="opacity" class="demo" data-opacity=".5" value="#766fa8">
+    </div>
+    <div class="form-group">
+        <label for="keywords">Keywords</label>
+        <br>
+        <input type="text" id="keywords" class="demo" data-keywords="transparent, inherit, initial" value="transparent">
     </div>
     <div class="form-group">
         <label for="default-value">Default Value</label>


### PR DESCRIPTION
This PR is created to answer this request :
https://github.com/claviska/jquery-minicolors/issues/75
But too, it is to able new possibilities, requested by Joomla users (as this great color picker is used inside Joomla core since 3 years!) : 
https://github.com/joomla/joomla-cms/pull/7602

It allows to save input with a rgba value, when opacity is activated.
It will automatically populate the field input with a rgba string, if data-opacity is set.
If opacity is 1, the hex value will be used.

It adds too the possibility to use css color keywords such as transparent, inherit, initial, depending of the option set for keywords.
You can set keywords like this : 
<pre>keywords: 'transparency, inherit, initial',</pre>
Note: "none" could be used too, but it's not a valid w3c keyword for a css color attribute, so, if none is added in the keywords option, a use will be able to enter "none", the script will convert it to "transparent".

All feedback welcome! ;-)
Cyril


