### PR TITLE
Remove prefixed -moz-box-sizing

### DIFF
--- a/jquery.minicolors.css
+++ b/jquery.minicolors.css
@@ -48,7 +48,6 @@
     border: solid 1px #CCC;
     box-shadow: 0 0 20px rgba(0, 0, 0, .2);
     z-index: 99999;
-    -moz-box-sizing: content-box;
     -webkit-box-sizing: content-box;
     box-sizing: content-box;
     display: none;
@@ -178,7 +177,6 @@
     height: 8px;
     border-radius: 8px;
     border: solid 2px white;
-    -moz-box-sizing: content-box;
     -webkit-box-sizing: content-box;
     box-sizing: content-box;
 }
@@ -192,7 +190,6 @@
     background: white;
     border: solid 1px black;
     margin-top: -2px;
-    -moz-box-sizing: content-box;
     -webkit-box-sizing: content-box;
     box-sizing: content-box;
 }


### PR DESCRIPTION
Since firefox 29 this is not needed anymore https://developer.mozilla.org/en-US/Firefox/Releases/29 Also the ESR version is currently on 38 and going to 45 soon.