### PR TITLE
Respect top.document

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -1001,7 +1001,7 @@
     }
 
     // Handle events
-    $(document)
+    $([document, top.document])
         // Hide on clicks outside of the control
         .on('mousedown.minicolors touchstart.minicolors', function(event) {
             if( !$(event.target).parents().add(event.target).hasClass('minicolors') ) {

--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -1012,12 +1012,12 @@
         .on('mousedown.minicolors touchstart.minicolors', '.minicolors-grid, .minicolors-slider, .minicolors-opacity-slider', function(event) {
             var target = $(this);
             event.preventDefault();
-            $(document).data('minicolors-target', target);
+            $(event.delegateTarget).data('minicolors-target', target);
             move(target, event, true);
         })
         // Move pickers
         .on('mousemove.minicolors touchmove.minicolors', function(event) {
-            var target = $(document).data('minicolors-target');
+            var target = $(event.delegateTarget).data('minicolors-target');
             if( target ) move(target, event);
         })
         // Stop moving


### PR DESCRIPTION
`top.document` should be taken into account in case the color picker is not displayed in the same frame as it was generated.

Resolves #206