### PR TITLE
remove swatch limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
                         <div class="form-group">
                             <label for="letter-case">Swatches</label>
                             <br>
-                            <input type="text" id="swatches" class="form-control demo" data-swatches="#fff|#000|#f00|#0f0|#00f|#ff0|#0ff" value="#abcdef">
+                            <input type="text" id="swatches" class="form-control demo" data-swatches="#ef9a9a|#90caf9|#a5d6a7|#fff59d|#ffcc80|#bcaaa4|#eeeeee|#f44336|#2196f3|#4caf50|#ffeb3b|#ff9800|#795548|#9e9e9e" value="#abcdef">
                             <span class="help-block">
                                 Example with swatches.
                             </span>
@@ -581,7 +581,7 @@ $.minicolors.defaults = $.extend($.minicolors.defaults, {
                 <dd>
                     <p>
                         An array containing some colors, in either rgb(a) or hex format, that will
-                        show up under the main color grid. There can be only up to 7 colors.
+                        show up under the main color grid.
                     </p>
                 </dd>
             </dl>

--- a/jquery.minicolors.css
+++ b/jquery.minicolors.css
@@ -43,17 +43,12 @@
 .minicolors-panel {
     position: absolute;
     width: 173px;
-    height: 152px;
     background: white;
     border: solid 1px #CCC;
     box-shadow: 0 0 20px rgba(0, 0, 0, .2);
     z-index: 99999;
     box-sizing: content-box;
     display: none;
-}
-
-.minicolors-panel.minicolors-with-swatches {
-	height: 182px;
 }
 
 .minicolors-panel.minicolors-visible {
@@ -82,7 +77,7 @@
 }
 
 .minicolors .minicolors-grid {
-    position: absolute;
+    position: relative;
     top: 1px;
     left: 1px;
     width: 150px;
@@ -194,28 +189,25 @@
 /* Swatches */
 .minicolors-swatches,
 .minicolors-swatches li {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	overflow: hidden;
-	position: absolute;
-	top: 157px;
-	left: 5px;
+    margin: 5px 0 3px 5px;
+    padding: 0;
+    list-style: none;
+    overflow: hidden;
 }
 
 .minicolors-swatches .minicolors-swatch {
-	position: relative;
-	float: left;
-	cursor: pointer;
-	margin:0 4px 0 0;
+    position: relative;
+    float: left;
+    cursor: pointer;
+    margin:0 4px 0 0;
 }
 
 .minicolors-with-opacity .minicolors-swatches .minicolors-swatch {
-	margin-right: 7px;
+    margin-right: 7px;
 }
 
 .minicolors-swatch.selected {
-	border-color: #000;
+    border-color: #000;
 }
 
 /* Inline controls */
@@ -244,13 +236,11 @@
     height: 18px;
 }
 .minicolors-theme-default .minicolors-swatches .minicolors-swatch {
+    margin-bottom: 2px;
     top: 0;
     left: 0;
     width: 18px;
     height: 18px;
-}
-.minicolors-theme-default .minicolors-swatches {
-	height: 20px;
 }
 .minicolors-theme-default.minicolors-position-right .minicolors-swatch {
     left: auto;
@@ -281,6 +271,7 @@
     border-radius: 3px;
 }
 .minicolors-theme-bootstrap .minicolors-swatches .minicolors-swatch {
+    margin-bottom: 2px;
     top: 0;
     left: 0;
     width: 20px;

--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -220,9 +220,6 @@
 
         // Swatches
         if (settings.swatches && settings.swatches.length !== 0) {
-            if (settings.swatches.length > 7) {
-                settings.swatches.length = 7;
-            }
             panel.addClass('minicolors-with-swatches');
             swatches = $('<ul class="minicolors-swatches"></ul>')
                 .appendTo(panel);

--- a/without-bootstrap.html
+++ b/without-bootstrap.html
@@ -173,7 +173,7 @@
     <div class="form-group">
         <label for="letter-case">Swatches</label>
         <br>
-        <input type="text" id="swatches" class="demo" data-swatches="#fff|#000|#f00|#0f0|#00f|#ff0|#0ff" value="#f00">
+        <input type="text" id="swatches" class="demo" data-swatches="#ef9a9a|#90caf9|#a5d6a7|#fff59d|#ffcc80|#bcaaa4|#eeeeee|#f44336|#2196f3|#4caf50|#ffeb3b|#ff9800|#795548|#9e9e9e" value="#f00">
     </div>
     <div class="form-group">
         <label for="letter-case">Swatches and opacity</label>


### PR DESCRIPTION
fix #215

I removed the 7 swatches limit by tweaking the css & showcased it in the index page with 2 lines of swatches

I also removed some `tab` indentation in the css and replaced with spaces