### PR TITLE
Use peer dependency for jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "colorpicker"
   ],
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">= 1.7.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes issues when using with webpack. If a peer dep isn't used it requires it's own version of jQuery which is different to the global jQuery you would pull in elsewhere.