### PR TITLE
Allow for objects in swatches array (optional)

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -142,6 +142,7 @@
   function init(input, settings) {
     var minicolors = $('<div class="minicolors" />');
     var defaults = $.minicolors.defaults;
+    var name;
     var size;
     var swatches;
     var swatch;
@@ -214,9 +215,16 @@
       swatches = $('<ul class="minicolors-swatches"></ul>')
       .appendTo(panel);
       for(i = 0; i < settings.swatches.length; ++i) {
-        swatch = settings.swatches[i];
+        // allow for custom objects as swatches
+        if($.type(settings.swatches[i]) === "object") {
+          name = settings.swatches[i].name;
+          swatch = settings.swatches[i].color;
+        } else {
+          name = '';
+          swatch = settings.swatches[i];
+        }
         swatch = isRgb(swatch) ? parseRgb(swatch, true) : hex2rgb(parseHex(swatch, true));
-        $('<li class="minicolors-swatch minicolors-sprite"><span class="minicolors-swatch-color"></span></li>')
+        $('<li class="minicolors-swatch minicolors-sprite"><span class="minicolors-swatch-color" title="' + name + '"></span></li>')
         .appendTo(swatches)
         .data('swatch-color', settings.swatches[i])
         .find('.minicolors-swatch-color')


### PR DESCRIPTION
This give the possibility to add a title/description/color name to predefined colors, often clients ask for that if they have to follow some kind of corporate style guide...

rather simple change, it is now possible to specify the swatches option like that:

```js
$colorinput.minicolors({
	// ... other options
	swatches: [ // predefined colors
		{name: 'deep-space (very dark blue)', color: '#0D2345'},
		{name: 'some-blue (corporate color)', color: '#0082CA'},
		{name: 'green-apple (very sour)', color: '#05DCAC'}
	]
});
```

backwards compatibility is of course there as it now can deal with objects if passed, otherwise it will just work like before.

If an object like above is passed the description/text/name whatever we want to call it will be added as a simple title attribute to the predefined color swatches in the picker and will be shown on mouseover (stay a little longer over it, nothing changed there in the default browser behaviour).