### PR TITLE
Refactor jQuery 3.x deprecations

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -217,7 +217,7 @@
         .appendTo(panel);
       for(i = 0; i < settings.swatches.length; ++i) {
         // allow for custom objects as swatches
-        if($.type(settings.swatches[i]) === 'object') {
+        if(typeof settings.swatches[i] === 'object') {
           name = settings.swatches[i].name;
           swatch = settings.swatches[i].color;
         } else {
@@ -605,7 +605,7 @@
 
     // Get array of lowercase keywords
     keywords = !settings.keywords ? [] : $.map(settings.keywords.split(','), function(a) {
-      return $.trim(a.toLowerCase());
+      return a.toLowerCase().trim();
     });
 
     // Set color string
@@ -1050,7 +1050,7 @@
 
       // Get array of lowercase keywords
       keywords = !settings.keywords ? [] : $.map(settings.keywords.split(','), function(a) {
-        return $.trim(a.toLowerCase());
+        return a.toLowerCase().trim();
       });
 
       // Set color string


### PR DESCRIPTION
During an upgrade of a codebase to jQuery 3.x, this plugin popped up when jQuery Migrate detected the use of a couple deprecated functions:

- `jQuery.type()` has been [deprecated in 3.3](https://api.jquery.com/jQuery.type/)
- `jQuery.trim()` has been [deprecated in 3.5](https://api.jquery.com/jQuery.trim/)

Both deprecations have straightforward vanilla JS replacements.

Please let me know if you want me to make any changes & thank you for the work you do!