### PR TITLE
Fix transparent watches 

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -231,7 +231,7 @@
           .data('swatch-color', swatchString)
           .find('.minicolors-swatch-color')
           .css({
-            backgroundColor: rgb2hex(swatch),
+            backgroundColor: ((swatchString !== 'transparent') ? rgb2hex(swatch) : 'transparent'),
             opacity: String(swatch.a)
           });
         settings.swatches[i] = swatch;


### PR DESCRIPTION
Fix issue #293.
Transparent swatches are shown with black background-color.

After:
![Captura de pantalla 2021-01-27 a las 13 47 06](https://user-images.githubusercontent.com/524030/106944000-62446600-6726-11eb-95f4-b5ad8806b8cb.png)

Before:
<img width="179" alt="Captura de pantalla 2021-02-04 a las 20 19 48" src="https://user-images.githubusercontent.com/524030/106944034-6bcdce00-6726-11eb-81b5-96b897fd34ee.png">

