### PR TITLE
Used 'addBack' instead of 'add' for clarity and consistency

### DIFF
--- a/jquery.minicolors.js
+++ b/jquery.minicolors.js
@@ -998,7 +998,7 @@
   $([document])
     // Hide on clicks outside of the control
     .on('mousedown.minicolors touchstart.minicolors', function(event) {
-      if(!$(event.target).parents().add(event.target).hasClass('minicolors')) {
+      if(!$(event.target).parents().addBack().hasClass('minicolors')) {
         hide();
       }
     })


### PR DESCRIPTION
`$(event.target).parents().addBack()` adds the set of all parent elements of the `event.target` element, including the event.target element itself, to the set of matched elements

`addBack()` is more useful when need to add elements that were previously filtered out, while `add()` is more useful when need to add elements that were not part of the original set